### PR TITLE
Added option "HDMI combined sync" which enables RGBS output from HDMI

### DIFF
--- a/rtl/ossc_pro.v
+++ b/rtl/ossc_pro.v
@@ -470,6 +470,7 @@ assign HDMITX_PCLK_o = ~pclk_out;
 
 // VIP / LB
 wire vip_select = misc_config2[3];
+wire hdmi_csync = misc_config2[4];
 wire lb_enable = sys_poweron & ~testpattern_enable & ~vip_select;
 
 always @(posedge pclk_capture) begin
@@ -610,7 +611,7 @@ always @(posedge pclk_out) begin
 `endif
     HDMITX_G_o <= G_out;
     HDMITX_B_o <= B_out;
-    HDMITX_HSYNC_o <= HSYNC_out;
+    HDMITX_HSYNC_o <= hdmi_csync ? ~(HSYNC_out ^ VSYNC_out) : HSYNC_out;
     HDMITX_VSYNC_o <= VSYNC_out;
     HDMITX_DE_o <= DE_out;
 end

--- a/software/sys_controller/av_controller.c
+++ b/software/sys_controller/av_controller.c
@@ -511,6 +511,7 @@ void update_sc_config(mode_data_t *vm_in, mode_data_t *vm_out, vm_proc_config_t 
     misc_config.shmask_iv_y = shmask_data_arr_ptr->iv_y;
     misc_config2.lumacode_mode = avconfig->lumacode_mode;
     misc_config2.vip_enable = vip_enable;
+    misc_config2.hdmi_csync = avconfig->hdmi_csync;
 
     // set default/custom scanline interval
     sl_def_iv_y = (vm_conf->y_rpt > 0) ? vm_conf->y_rpt : 1;

--- a/software/sys_controller/inc/avconfig.h
+++ b/software/sys_controller/inc/avconfig.h
@@ -173,6 +173,7 @@ typedef struct {
     uint8_t lumacode_mode;
     uint8_t lumacode_pal;
     uint8_t ypbpr_cs;
+    uint8_t hdmi_csync;
     /* Common LM settings */
     uint8_t lm_deint_mode;
     uint8_t nir_even_offset;

--- a/software/sys_controller/src/menu.c
+++ b/software/sys_controller/src/menu.c
@@ -492,6 +492,7 @@ MENU(menu_output, P99_PROTECT({
     { LNG("TX mode","TXﾓｰﾄﾞ"),                  OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.tx_mode,  OPT_WRAP, SETTING_ITEM_LIST(tx_mode_desc) } } },
     { "HDMI HDR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.hdr,      OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
     { "HDMI VRR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.vrr,      OPT_WRAP, SETTING_ITEM(hdmi_vrr_desc) } } },
+    { "HDMI combined sync",                    OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_csync,          OPT_WRAP, SETTING_ITEM_LIST(off_on_desc) } } },
     //{ "HDMI ITC",                              OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_itc,        OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
 #ifndef DExx_FW
     { LNG("Full TX setup","ﾌﾙTXｾｯﾄｱｯﾌﾟ"),       OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.full_tx_setup, OPT_WRAP, SETTING_ITEM(off_on_desc) } } },

--- a/software/sys_controller/src/userdata.c
+++ b/software/sys_controller/src/userdata.c
@@ -210,6 +210,7 @@ const ude_item_map ude_profile_items[] = {
     UDE_ITEM(108, 80, tc.scl_dil_cadence22_comb_thold),
 #endif
 #endif
+    UDE_ITEM(109, 80, tc.hdmi_csync),
 };
 
 int write_userdata(uint8_t entry) {


### PR DESCRIPTION
Added option "HDMI combined sync" which enables RGBS output from HDMI port when using HDMI to VGA DACs.
Tested using 15KHz downscaler in adaptive and scaler modes and also with Legacy AV In add-on to transcode CVBS to RGBS.