### PR TITLE
Fixed wrong CSync implementation affecting 480i field alignment and c…

### DIFF
--- a/ip/sc_config/inc/sc_config_regs.h
+++ b/ip/sc_config/inc/sc_config_regs.h
@@ -128,7 +128,8 @@ typedef union {
         uint8_t lumacode_mode:3;
         uint8_t vip_enable:1;
         uint8_t hdmi_csync:1;
-        uint32_t misc2_rsv:27;
+        uint8_t csync_combiner:2;
+        uint32_t misc2_rsv:25;
     } __attribute__((packed, __may_alias__));
     uint32_t data;
 } misc_config2_reg;

--- a/rtl/ossc_pro.v
+++ b/rtl/ossc_pro.v
@@ -611,7 +611,7 @@ always @(posedge pclk_out) begin
 `endif
     HDMITX_G_o <= G_out;
     HDMITX_B_o <= B_out;
-    HDMITX_HSYNC_o <= hdmi_csync ? ~(HSYNC_out ^ VSYNC_out) : HSYNC_out;
+    HDMITX_HSYNC_o <= hdmi_csync ? HSYNC_out & VSYNC_out : HSYNC_out;
     HDMITX_VSYNC_o <= VSYNC_out;
     HDMITX_DE_o <= DE_out;
 end
@@ -657,10 +657,10 @@ always @(posedge pclk_out) begin
         VGA_R_pre <= VGA_CSC_R_out;
         VGA_G_pre <= VGA_CSC_G_out;
         VGA_B_pre <= VGA_CSC_B_out;
-        VGA_HS_pre <= (extra_out_mode == EXTRA_OUT_RGBHV) ? VGA_CSC_HSYNC_out : ~(VGA_CSC_HSYNC_out ^ VGA_CSC_VSYNC_out);
+        VGA_HS_pre <= (extra_out_mode == EXTRA_OUT_RGBHV) ? VGA_CSC_HSYNC_out : VGA_CSC_HSYNC_out & VGA_CSC_VSYNC_out;
         VGA_VS_pre <= (extra_out_mode == EXTRA_OUT_RGBHV) ? VGA_CSC_VSYNC_out : 1'b1;
         VGA_BLANK_N_pre <= (extra_out_mode == EXTRA_OUT_YPbPr) ? 1'b1 : VGA_CSC_DE_out;
-        VGA_SYNC_N_pre <= (extra_out_mode >= EXTRA_OUT_RGsB) ? ~(VGA_CSC_HSYNC_out ^ VGA_CSC_VSYNC_out) : 1'b0;
+        VGA_SYNC_N_pre <= (extra_out_mode >= EXTRA_OUT_RGsB) ? VGA_CSC_HSYNC_out & VGA_CSC_VSYNC_out : 1'b0;
 
         VGA_R <= VGA_R_pre;
         VGA_G <= VGA_G_pre;

--- a/software/sys_controller/av_controller.c
+++ b/software/sys_controller/av_controller.c
@@ -514,6 +514,7 @@ void update_sc_config()
     misc_config2.lumacode_mode = avconfig->lumacode_mode;
     misc_config2.vip_enable = vip_enable;
     misc_config2.hdmi_csync = avconfig->hdmi_csync;
+    misc_config2.csync_combiner = avconfig->csync_combiner;
 
     // set default/custom scanline interval
     sl_def_iv_y = (vm_conf.y_rpt > 0) ? vm_conf.y_rpt : 1;

--- a/software/sys_controller/inc/avconfig.h
+++ b/software/sys_controller/inc/avconfig.h
@@ -174,6 +174,7 @@ typedef struct {
     uint8_t lumacode_pal;
     uint8_t ypbpr_cs;
     uint8_t hdmi_csync;
+    uint8_t csync_combiner;
     /* Common LM settings */
     uint8_t lm_deint_mode;
     uint8_t nir_even_offset;

--- a/software/sys_controller/src/menu.c
+++ b/software/sys_controller/src/menu.c
@@ -129,6 +129,7 @@ static const char* const lm_deint_mode_desc[] = { "Bob", "Noninterlace restore" 
 static const char* const ar_256col_desc[] = { "Pseudo 4:3 DAR", "1:1 PAR" };
 static const char* const tx_mode_desc[] = { "HDMI (RGB Full)", "HDMI (RGB Limited)", "HDMI (YCbCr444)", "DVI" };
 static const char* const hdmi_vrr_desc[] = { "Off", "Freesync" };
+static const char* const csync_combiner_desc[] = { "Type A (AND)", "Legacy (XNOR)" };
 static const char* const sl_mode_desc[] = { LNG("Off","ｵﾌ"), LNG("Auto","ｵｰﾄ"), LNG("On","ｵﾝ") };
 static const char* const sl_method_desc[] = { LNG("Multiplication","Multiplication"), LNG("Subtraction","Subtraction") };
 static const char* const sl_type_desc[] = { LNG("Horizontal","ﾖｺ"), LNG("Vertical","ﾀﾃ"), "Horiz. + Vert.", "Custom" };
@@ -502,6 +503,7 @@ MENU(menu_output, P99_PROTECT({
     { "HDMI HDR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.hdr,      OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
     { "HDMI VRR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.vrr,      OPT_WRAP, SETTING_ITEM(hdmi_vrr_desc) } } },
     { "HDMI combined sync",                    OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_csync,          OPT_WRAP, SETTING_ITEM_LIST(off_on_desc) } } },
+    { "CSync combiner",                        OPT_AVCONFIG_SELECTION, { .sel = { &tc.csync_combiner,      OPT_WRAP, SETTING_ITEM_LIST(csync_combiner_desc) } } },
     //{ "HDMI ITC",                              OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_itc,        OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
 #ifndef DExx_FW
     { LNG("Full TX setup","ﾌﾙTXｾｯﾄｱｯﾌﾟ"),       OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmitx_cfg.full_tx_setup, OPT_WRAP, SETTING_ITEM(off_on_desc) } } },

--- a/software/sys_controller/src/userdata.c
+++ b/software/sys_controller/src/userdata.c
@@ -214,6 +214,7 @@ const ude_item_map ude_profile_items[] = {
 #endif
     UDE_ITEM(109, 80, tc.hdmi_csync),
     // 110 reserved
+    UDE_ITEM(111, 80, tc.csync_combiner),
 };
 
 int write_userdata(uint8_t entry) {


### PR DESCRIPTION
Fixed wrong CSync implementation affecting 480i field alignment and causing curl on the top of the screen on some CRTs.